### PR TITLE
fix: generateContactLink 的 user_id 需要传 number 类型

### DIFF
--- a/auth/qclaw-api.ts
+++ b/auth/qclaw-api.ts
@@ -139,7 +139,7 @@ export class QClawAPI {
   async generateContactLink(openKfId: string): Promise<QClawApiResponse> {
     return this.post("data/4018/forward", {
       guid: this.guid,
-      user_id: this.userId,
+      user_id: Number(this.userId),
       open_id: openKfId,
       contact_type: "open_kfid",
     });


### PR DESCRIPTION
## 问题

PR #2 合并后，设备绑定仍然失败：

```
[device-bind] 生成企微客服链接...
[device-bind] 服务端未返回客服链接 URL
```

## 根因

`auth/qclaw-api.ts` 的 `generateContactLink` 方法中 `user_id: this.userId` 传的是 **string**，但 4018 接口要求 `user_id` 为 **number** 类型。字符串时服务端返回空结果，不带 URL。

## 修复

```diff
- user_id: this.userId,
+ user_id: Number(this.userId),
```

## 验证

使用相同的 token/guid/jwt，仅改变 `user_id` 类型：
- `user_id: "123456"` (string) → ❌ 服务端不返回 URL
- `user_id: 123456` (number) → ✅ 正常返回绑定链接

拿到链接后在微信中打开，绑定成功（昵称检测通过）✅

Fixes #1