### PR TITLE
fix: add guid and user_id to WebSocket connection URL

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -247,6 +247,8 @@ const tencentAccessPlugin = {
             ...(channels["wechat-access-unqclawed"] ?? {}),
             token: channelToken,
             wsUrl: env.wechatWsUrl,
+            guid,
+            userId: String(userInfo.user_id ?? ""),
           };
           const nextCfg: Record<string, unknown> = { ...fullCfg, channels };
           if (apiKey) {
@@ -379,11 +381,16 @@ const tencentAccessPlugin = {
         }
       }
 
+      // 从配置或已保存的登录态中获取 userId
+      const userId = tencentAccessConfig?.userId
+        ? String(tencentAccessConfig.userId)
+        : String((savedState?.userInfo as Record<string, unknown>)?.user_id ?? "");
+
       const wsConfig = {
         url: wsUrl,
         token,
         guid,
-        userId: "",
+        userId,
         gatewayPort,
         reconnectInterval: 3000,
         maxReconnectAttempts: 10,
@@ -558,6 +565,8 @@ const tencentAccessPlugin = {
             channels["wechat-access-unqclawed"] = {
               ...(channels["wechat-access-unqclawed"] ?? {}),
               token: channelToken,
+              guid,
+              userId: String(userInfo.user_id ?? ""),
             };
             const nextCfg: Record<string, unknown> = { ...fullCfg, channels };
             if (apiKey) {

--- a/websocket/websocket-client.ts
+++ b/websocket/websocket-client.ts
@@ -293,6 +293,12 @@ export class WechatAccessWebSocketClient {
     if (this.config.token) {
       url.searchParams.set("token", this.config.token);
     }
+    if (this.config.guid) {
+      url.searchParams.set("guid", this.config.guid);
+    }
+    if (this.config.userId) {
+      url.searchParams.set("user_id", this.config.userId);
+    }
     return url.toString();
   };
 


### PR DESCRIPTION
## 问题

WebSocket 连接成功握手后立刻被服务端断开（code=1006），提示"设备不在线"。

日志可以看到 `userId=` 为空，且连接 URL 只有 `token` 参数：
```
连接配置: url=wss://mmgrcalltoken.3g.qq.com/agentwss, token=85a401..., guid=0adc37b..., userId=
正在连接: wss://mmgrcalltoken.3g.qq.com/agentwss?token=85a401...
WebSocket 连接断开: code=1006
```

AGP 协议要求握手时携带 `token`、`guid`、`user_id` 三个参数，缺少后两个导致服务端拒绝连接。

## 修复

三个关联 bug：

### 1. `websocket/websocket-client.ts` — `buildConnectionUrl()` 缺少参数

`buildConnectionUrl()` 只拼了 `token`，现在补上 `guid` 和 `user_id`：

```diff
  private buildConnectionUrl = (): string => {
    const url = new URL(this.config.url);
    if (this.config.token) {
      url.searchParams.set("token", this.config.token);
    }
+   if (this.config.guid) {
+     url.searchParams.set("guid", this.config.guid);
+   }
+   if (this.config.userId) {
+     url.searchParams.set("user_id", this.config.userId);
+   }
    return url.toString();
  };
```

### 2. `index.ts` — `startAccount` 中 `userId` 硬编码为空

WebSocket 配置中 `userId: ""` 应该从渠道配置或已保存的登录态中读取：

```diff
+ const userId = tencentAccessConfig?.userId
+   ? String(tencentAccessConfig.userId)
+   : String((savedState?.userInfo as Record<string, unknown>)?.user_id ?? "");
+
  const wsConfig = {
    url: wsUrl,
    token,
    guid,
-   userId: "",
+   userId,
    ...
  };
```

### 3. `index.ts` — 登录时未持久化 `guid` 和 `userId`

`auth.login` 和 `loginWithQrWait` 写入 `openclaw.json` 时只保存了 `token`（和 `wsUrl`），没有保存 `guid` 和 `userId`，导致 Gateway 重启后这两个值丢失：

```diff
  channels["wechat-access-unqclawed"] = {
    ...(channels["wechat-access-unqclawed"] ?? {}),
    token: channelToken,
    wsUrl: env.wechatWsUrl,
+   guid,
+   userId: String(userInfo.user_id ?? ""),
  };
```

## 参考

对比了 [reloadggg/wechat-access-plugin](https://github.com/reloadggg/wechat-access-plugin) 的实现，该项目正确地在连接 URL 中包含了所有三个参数。

Fixes #6